### PR TITLE
remove tags: do not track tags files in plugins

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,4 +1,0 @@
-FYT-about	FYT.txt	/*FYT-about*
-FYT-configuration	FYT.txt	/*FYT-configuration*
-FYT.txt	FYT.txt	/*FYT.txt*
-FYT.vim	FYT.txt	/*FYT.vim*


### PR DESCRIPTION
Rationale: https://github.com/tpope/vim-pathogen#faq (see section on
tags).

I ignore tags files in my Dotfiles and update them when I want with
`:helptags`. I assume plugins do not track their own!

Simply removing the file should solve my issue; ignoring it in this repo
(e.g., via a committed .gitignore) should be unnecessary.